### PR TITLE
fix jar confict lead to javax.ws.rs.ClientErrorException.validate .

### DIFF
--- a/application/tool/tool-core/pom.xml
+++ b/application/tool/tool-core/pom.xml
@@ -365,11 +365,11 @@
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
             <version>${cxf-rt-frontend-jaxrs}</version>
         </dependency>
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1-m09</version>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>javax.ws.rs</groupId>-->
+            <!--<artifactId>javax.ws.rs-api</artifactId>-->
+            <!--<version>2.1-m09</version>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-extension-providers</artifactId>


### PR DESCRIPTION
jsr311-api and javax.ws.rs-api has WebApplicationException ,  conflict lead to ClientErrorException .validate ()

can not get validate method.

throws javax.ws.rs.ClientErrorException.validate (...)